### PR TITLE
Don't remove DHCP config on restart

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -253,7 +253,7 @@ class DhcpLocalProcess(DhcpBase):
             common_utils.wait_until_true(lambda: not self.active)
         if not retain_port:
             self._destroy_namespace_and_port()
-        self._remove_config_files()
+            self._remove_config_files()
 
     def _destroy_namespace_and_port(self):
         try:


### PR DESCRIPTION
Currently the DHCP agent regenerates all configuration files on restart.
This means that DHCPv6 leases are lost as they can't be regenerated.
This changes the agent to only delete the config files if the agent's
ports are also removed.

Change-Id: I25742880b24f31a1b52a84487bd3d85996102d76