### PR TITLE
Faster VLAN children lookup for linuxbridge agent

### DIFF
--- a/neutron/services/trunk/drivers/linuxbridge/agent/trunk_plumber.py
+++ b/neutron/services/trunk/drivers/linuxbridge/agent/trunk_plumber.py
@@ -110,7 +110,24 @@ class Plumber(object):
 
     def _get_vlan_children(self, dev):
         """Return set of (devname, vlan_id) tuples for children of device."""
-        devices = ip_lib.get_devices_info(namespace=self.namespace)
-        return {(device['name'], device['vlan_id']) for device in devices
-                if device.get('kind') == 'vlan' and
-                device.get('parent_name') == dev}
+
+        # Get the parent device(s)
+        parents = ip_lib.get_devices_info(namespace=self.namespace, ifname=dev)
+
+        if not parents:
+            return set()
+
+        # Linux doesn't seem to allow this. But if it did, this function
+        # would not be able accurately return the right VLAN children.
+        if len(parents) > 1:
+            raise RuntimeError(f"More than one interface named {dev}")
+
+        children = ip_lib.get_devices_info(
+            namespace=self.namespace,
+            link=parents[0]['index'],
+        )
+
+        return {
+            (device['name'], device['vlan_id']) for device in children
+            if device.get('kind') == 'vlan'
+        }


### PR DESCRIPTION
Before this commit, the `Plumber._get_vlan_children` function in the linuxbridge agent loaded all the network interfaces to look for parent/child relationships.

This takes seconds on a system with hundreds of network devices and causes the wiring the linuxbridge agent performs, to be a lot slower than it needs to be.

This change passes filters down to `pyroute2` to avoid loading so many interfaces. Instead, only the parent is loaded once, and then the `IFLA_LINK` attribute is used (via the `link` argument), to look for interfaces that point to this parent.